### PR TITLE
introducing subsampling of interior and boundary time step

### DIFF
--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -247,6 +247,18 @@ def main(input_args=None):
         default=1,
         help="Number of future time steps to use as input for boundary data",
     )
+    parser.add_argument(
+        "--interior_subsample_step",
+        type=int,
+        default=1,
+        help="Subsample step for interior grid nodes",
+    )
+    parser.add_argument(
+        "--boundary_subsample_step",
+        type=int,
+        default=1,
+        help="Subsample step for boundary grid nodes",
+    )
     args = parser.parse_args(input_args)
     args.var_leads_metrics_watch = {
         int(k): v for k, v in json.loads(args.var_leads_metrics_watch).items()
@@ -285,6 +297,8 @@ def main(input_args=None):
         num_future_forcing_steps=args.num_future_forcing_steps,
         num_past_boundary_steps=args.num_past_boundary_steps,
         num_future_boundary_steps=args.num_future_boundary_steps,
+        interior_subsample_step=args.interior_subsample_step,
+        boundary_subsample_step=args.boundary_subsample_step,
         batch_size=args.batch_size,
         num_workers=args.num_workers,
     )

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -53,9 +53,25 @@ class WeatherDataset(torch.utils.data.Dataset):
         boundary from times t, t+1, ..., t+j-1, t+j (and potentially times
         before t, given num_past_forcing_steps) are included as boundary inputs
         at time t. Default is 1.
+    interior_subsample_step : int, optional
+        The stride/step size used when sampling interior domain data points. A
+        value of N means only every Nth point will be sampled in the temporal
+        dimension. For example, if step_length=3 hours and
+        interior_subsample_step=2, data will be sampled every 6 hours. Default
+        is 1 (use every timestep).
+    boundary_subsample_step : int, optional
+        The stride/step size used when sampling boundary condition data points.
+        A value of N means only every Nth point will be sampled in the temporal
+        dimension. For example, if step_length=3 hours and
+        boundary_subsample_step=2, boundary conditions will be sampled every 6
+        hours. Default is 1 (use every timestep).
     standardize : bool, optional
         Whether to standardize the data. Default is True.
     """
+
+    # The current implementation requires at least 2 time steps for the
+    # initial state (see GraphCast).
+    INIT_STEPS = 2  # Number of initial state steps needed
 
     def __init__(
         self,
@@ -67,6 +83,8 @@ class WeatherDataset(torch.utils.data.Dataset):
         num_future_forcing_steps=1,
         num_past_boundary_steps=1,
         num_future_boundary_steps=1,
+        interior_subsample_step=1,
+        boundary_subsample_step=1,
         standardize=True,
     ):
         super().__init__()
@@ -79,6 +97,37 @@ class WeatherDataset(torch.utils.data.Dataset):
         self.num_future_forcing_steps = num_future_forcing_steps
         self.num_past_boundary_steps = num_past_boundary_steps
         self.num_future_boundary_steps = num_future_boundary_steps
+        self.interior_subsample_step = interior_subsample_step
+        self.boundary_subsample_step = boundary_subsample_step
+        # Scale forcing steps based on subsampling
+        self.effective_past_forcing_steps = (
+            num_past_forcing_steps * interior_subsample_step
+        )
+        self.effective_future_forcing_steps = (
+            num_future_forcing_steps * interior_subsample_step
+        )
+        self.effective_past_boundary_steps = (
+            num_past_boundary_steps * boundary_subsample_step
+        )
+        self.effective_future_boundary_steps = (
+            num_future_boundary_steps * boundary_subsample_step
+        )
+
+        # Validate subsample steps
+        if (
+            not isinstance(interior_subsample_step, int)
+            or interior_subsample_step < 1
+        ):
+            raise ValueError(
+                "interior_subsample_step must be a positive integer"
+            )
+        if (
+            not isinstance(boundary_subsample_step, int)
+            or boundary_subsample_step < 1
+        ):
+            raise ValueError(
+                "boundary_subsample_step must be a positive integer"
+            )
 
         self.da_state = self.datastore.get_dataarray(
             category="state", split=self.split
@@ -144,8 +193,6 @@ class WeatherDataset(torch.utils.data.Dataset):
             )
             i_ensemble = 0
             self.da_state = self.da_state.isel(ensemble_member=i_ensemble)
-        else:
-            self.da_state = self.da_state
 
         # Check time step consistency in state data and determine time steps
         # for state, forcing and boundary forcing data
@@ -168,6 +215,16 @@ class WeatherDataset(torch.utils.data.Dataset):
             else:
                 forcing_times = self.da_forcing.time
             self.time_step_forcing = get_time_step(forcing_times.values)
+        # inform user about the original and the subsampled time step
+        if self.interior_subsample_step != 1:
+            print(
+                f"Subsampling interior data with step size "
+                f"{self.interior_subsample_step} from original time step "
+                f"{self.time_step_state}"
+            )
+        else:
+            print(f"Using original time step {self.time_step_state} for data")
+
         # BOUNDARY FORCING
         if self.da_boundary_forcing is not None:
             if self.datastore_boundary.is_forecast:
@@ -179,13 +236,24 @@ class WeatherDataset(torch.utils.data.Dataset):
                 boundary_times = self.da_boundary_forcing.time
             self.time_step_boundary = get_time_step(boundary_times.values)
 
+            if self.boundary_subsample_step != 1:
+                print(
+                    f"Subsampling boundary data with step size "
+                    f"{self.boundary_subsample_step} from original time step "
+                    f"{self.time_step_boundary}"
+                )
+            else:
+                print(
+                    f"Using original time step {self.time_step_boundary} for "
+                    "boundary data"
+                )
+
         # Forcing data is part of the same datastore as state data. During
         # creation, the time dimension of the forcing data is matched to the
         # state data.
         # Boundary data is part of a separate datastore The boundary data is
         # allowed to have a different time_step Checks that the boundary data
         # covers the required time range is required.
-
         # Crop interior data if boundary coverage is insufficient
         if self.da_boundary_forcing is not None:
             self.da_state = crop_time_if_needed(
@@ -255,32 +323,47 @@ class WeatherDataset(torch.utils.data.Dataset):
             # This means that for each analysis time we get a single sample
             # check that there are enough forecast steps available to create
             # samples given the number of autoregressive steps requested
-            n_forecast_steps = self.da_state.elapsed_forecast_duration.size
-            if n_forecast_steps < 2 + self.ar_steps:
+            required_steps = self.INIT_STEPS + self.ar_steps
+            required_span = (required_steps - 1) * self.interior_subsample_step
+
+            # Calculate available forecast steps
+            n_forecast_steps = len(self.da_state.elapsed_forecast_duration)
+
+            if n_forecast_steps < required_span:
                 raise ValueError(
-                    "The number of forecast steps available "
-                    f"({n_forecast_steps}) is less than the required "
-                    f"2+ar_steps (2+{self.ar_steps}={2 + self.ar_steps}) for "
-                    "creating a sample with initial and target states."
+                    f"Not enough forecast steps ({n_forecast_steps}) for "
+                    f"required span of {required_span} steps with "
+                    f"subsample_step={self.interior_subsample_step}"
                 )
 
             return self.da_state.analysis_time.size
         else:
-            # Calculate the number of samples in the dataset n_samples = total
-            # time steps - (autoregressive steps + past forcing + future
-            # forcing)
-            #:
+            # Calculate the number of samples in the dataset as:
+            # total_samples = total_timesteps - required_time_span -
+            # required_past_steps - effective_future_forcing_steps
             # Where:
-            #   - total time steps: len(self.da_state.time)
-            #   - autoregressive steps: self.ar_steps
-            #   - past forcing: max(2, self.num_past_forcing_steps) (at least 2
-            #     time steps are required for the initial state)
-            #   - future forcing: self.num_future_forcing_steps
+            # - total_timesteps: total number of timesteps in the state data
+            # - required_time_span: number of continuous timesteps needed for
+            #   initial state + autoregressive steps, accounting for subsampling
+            # - required_past_steps: additional past timesteps needed for
+            #   forcing data beyond initial state
+            # - effective_future_forcing_steps: number of future timesteps
+            #   needed for forcing data with subsampling
+            required_continuous_steps = self.INIT_STEPS + self.ar_steps
+            required_time_span = (
+                required_continuous_steps * self.interior_subsample_step
+            )
+            required_past_steps = max(
+                0,
+                self.effective_past_forcing_steps
+                - self.INIT_STEPS * self.interior_subsample_step,
+            )
+
             return (
                 len(self.da_state.time)
-                - self.ar_steps
-                - max(2, self.num_past_forcing_steps)
-                - self.num_future_forcing_steps
+                - required_time_span
+                - required_past_steps
+                - self.effective_future_forcing_steps
             )
 
     def _slice_time(
@@ -333,24 +416,39 @@ class WeatherDataset(torch.utils.data.Dataset):
             'forcing/boundary_feature_windowed').
             If no forcing/boundary data is provided, this will be `None`.
         """
-        # The current implementation requires at least 2 time steps for the
-        # initial state (see GraphCast).
-        init_steps = 2
+        init_steps = self.INIT_STEPS
+        subsample_step = (
+            self.boundary_subsample_step
+            if is_boundary
+            else self.interior_subsample_step
+        )
         # slice the dataarray to include the required number of time steps
         if self.datastore.is_forecast:
-            start_idx = max(0, self.num_past_forcing_steps - init_steps)
-            end_idx = max(init_steps, self.num_past_forcing_steps) + n_steps
             # this implies that the data will have both `analysis_time` and
             # `elapsed_forecast_duration` dimensions for forecasts. We for now
             # simply select a analysis time and the first `n_steps` forecast
             # times (given no offset). Note that this means that we get one
             # sample per forecast, always starting at forecast time 2.
+
+            # Calculate base offset and indices with subsampling
+            offset = (
+                max(0, num_past_steps - init_steps) if num_past_steps else 0
+            )
+
+            # Calculate initial and target indices
+            init_indices = [
+                offset + i * subsample_step for i in range(init_steps)
+            ]
+            target_indices = [
+                offset + (init_steps + i) * subsample_step
+                for i in range(n_steps)
+            ]
+            all_indices = init_indices + target_indices
+
             da_state_sliced = da_state.isel(
                 analysis_time=idx,
-                elapsed_forecast_duration=slice(start_idx, end_idx),
+                elapsed_forecast_duration=all_indices,
             )
-            # create a new time dimension so that the produced sample has a
-            # `time` dimension, similarly to the analysis only data
             da_state_sliced["time"] = (
                 da_state_sliced.analysis_time
                 + da_state_sliced.elapsed_forecast_duration
@@ -360,12 +458,15 @@ class WeatherDataset(torch.utils.data.Dataset):
             )
 
         else:
-            # For analysis data we slice the time dimension directly. The offset
-            # is only relevant for the very first (and last) samples in the
-            # dataset.
-            start_idx = idx + max(0, num_past_steps - init_steps)
-            end_idx = idx + max(init_steps, num_past_steps) + n_steps
-            da_state_sliced = da_state.isel(time=slice(start_idx, end_idx))
+            # Analysis data slicing, already correctly modified
+            start_idx = idx + (
+                max(0, num_past_steps - init_steps) if num_past_steps else 0
+            )
+            all_indices = [
+                start_idx + i * subsample_step
+                for i in range(init_steps + n_steps)
+            ]
+            da_state_sliced = da_state.isel(time=all_indices)
 
         if da_forcing is None:
             return da_state_sliced, None
@@ -385,20 +486,33 @@ class WeatherDataset(torch.utils.data.Dataset):
             forcing_analysis_time_idx = da_forcing.analysis_time.get_index(
                 "analysis_time"
             ).get_indexer([state_time], method="pad")[0]
+
+            # Adjust window indices for subsampled steps
             for step_idx in range(init_steps, len(state_times)):
-                start_idx = offset + step_idx - num_past_steps
-                end_idx = offset + step_idx + num_future_steps + 1
+                window_start = (
+                    offset
+                    + step_idx * subsample_step
+                    - num_past_steps * subsample_step
+                )
+                window_end = (
+                    offset
+                    + step_idx * subsample_step
+                    + (num_future_steps + 1) * subsample_step
+                )
 
                 current_time = (
                     forcing_analysis_time_idx
-                    + da_forcing.elapsed_forecast_duration[step_idx]
+                    + da_forcing.elapsed_forecast_duration[
+                        step_idx * subsample_step
+                    ]
                 )
 
                 da_sliced = da_forcing.isel(
                     analysis_time=forcing_analysis_time_idx,
-                    elapsed_forecast_duration=slice(start_idx, end_idx),
+                    elapsed_forecast_duration=slice(
+                        window_start, window_end, subsample_step
+                    ),
                 )
-
                 da_sliced = da_sliced.rename(
                     {"elapsed_forecast_duration": "window"}
                 )
@@ -410,9 +524,11 @@ class WeatherDataset(torch.utils.data.Dataset):
                 # Calculate window time deltas for forecast data
                 window_time_deltas = (
                     da_forcing.elapsed_forecast_duration[
-                        start_idx:end_idx
+                        window_start:window_end:subsample_step
                     ].values
-                    - da_forcing.elapsed_forecast_duration[step_idx].values
+                    - da_forcing.elapsed_forecast_duration[
+                        step_idx * subsample_step
+                    ].values
                 )
                 # Assign window time delta coordinate
                 da_sliced["window_time_deltas"] = ("window", window_time_deltas)
@@ -433,21 +549,32 @@ class WeatherDataset(torch.utils.data.Dataset):
                     "time"
                 ).get_indexer([state_time], method="pad")[0]
 
-                # Use isel to select the window
-                da_window = da_forcing.isel(
-                    time=slice(
-                        forcing_time_idx - num_past_steps,
-                        forcing_time_idx + num_future_steps + 1,
-                    ),
+                window_start = (
+                    forcing_time_idx - num_past_steps * subsample_step
                 )
-                window_time_deltas = (da_window.time - state_time).values
+                window_end = (
+                    forcing_time_idx + (num_future_steps + 1) * subsample_step
+                )
+
+                da_window = da_forcing.isel(
+                    time=slice(window_start, window_end, subsample_step)
+                )
+
+                # Rename the time dimension to window for consistency
                 da_window = da_window.rename({"time": "window"})
 
-                # Assign 'window' coordinate
+                # Assign the 'window' coordinate to be relative positions
                 da_window = da_window.assign_coords(
                     window=np.arange(-num_past_steps, num_future_steps + 1)
                 )
-                # Assign window time delta coordinate
+
+                # Calculate window time deltas for analysis data
+                window_time_deltas = (
+                    da_forcing.time[
+                        window_start:window_end:subsample_step
+                    ].values
+                    - da_forcing.time[forcing_time_idx].values
+                )
                 da_window["window_time_deltas"] = ("window", window_time_deltas)
 
                 da_window = da_window.expand_dims(dim={"time": [state_time]})

--- a/neural_lam/weather_dataset.py
+++ b/neural_lam/weather_dataset.py
@@ -955,6 +955,8 @@ class WeatherDataModule(pl.LightningDataModule):
         num_future_forcing_steps=1,
         num_past_boundary_steps=1,
         num_future_boundary_steps=1,
+        interior_subsample_step=1,
+        boundary_subsample_step=1,
         batch_size=4,
         num_workers=16,
     ):
@@ -965,6 +967,8 @@ class WeatherDataModule(pl.LightningDataModule):
         self.num_future_forcing_steps = num_future_forcing_steps
         self.num_past_boundary_steps = num_past_boundary_steps
         self.num_future_boundary_steps = num_future_boundary_steps
+        self.interior_subsample_step = interior_subsample_step
+        self.boundary_subsample_step = boundary_subsample_step
         self.ar_steps_train = ar_steps_train
         self.ar_steps_eval = ar_steps_eval
         self.standardize = standardize
@@ -994,6 +998,8 @@ class WeatherDataModule(pl.LightningDataModule):
                 num_future_forcing_steps=self.num_future_forcing_steps,
                 num_past_boundary_steps=self.num_past_boundary_steps,
                 num_future_boundary_steps=self.num_future_boundary_steps,
+                interior_subsample_step=self.interior_subsample_step,
+                boundary_subsample_step=self.boundary_subsample_step,
             )
             self.val_dataset = WeatherDataset(
                 datastore=self._datastore,
@@ -1005,6 +1011,8 @@ class WeatherDataModule(pl.LightningDataModule):
                 num_future_forcing_steps=self.num_future_forcing_steps,
                 num_past_boundary_steps=self.num_past_boundary_steps,
                 num_future_boundary_steps=self.num_future_boundary_steps,
+                interior_subsample_step=self.interior_subsample_step,
+                boundary_subsample_step=self.boundary_subsample_step,
             )
 
         if stage == "test" or stage is None:
@@ -1018,6 +1026,8 @@ class WeatherDataModule(pl.LightningDataModule):
                 num_future_forcing_steps=self.num_future_forcing_steps,
                 num_past_boundary_steps=self.num_past_boundary_steps,
                 num_future_boundary_steps=self.num_future_boundary_steps,
+                interior_subsample_step=self.interior_subsample_step,
+                boundary_subsample_step=self.boundary_subsample_step,
             )
 
     def train_dataloader(self):

--- a/tests/dummy_datastore.py
+++ b/tests/dummy_datastore.py
@@ -37,7 +37,7 @@ class DummyDatastore(BaseRegularGridDatastore):
     bbox_size_km = [500, 500]  # km
 
     def __init__(
-        self, config_path=None, n_grid_points=10000, n_timesteps=10
+        self, config_path=None, n_grid_points=10000, n_timesteps=15
     ) -> None:
         """
         Create a dummy datastore with random data.


### PR DESCRIPTION
This introduces time step subsampling for both interior and boundary. Sometimes the required temporal resolution is lower than the one provided in the datastore or datastore_boundary. For that purpose weather_dataset has now two additional class-attributes, set by the user via argparse in `train_model`. The data will be subsampled lazily (at least for MDP datastore). This will not reduce the total number of samples (except at the edges). Sampling still occurs for each idx, just the time steps are increased. Test coverage is provided, even though the time delta test is still a bit too simplistic.