### PR TITLE
Implement hidden_dim_grid option and changes to model architecture

### DIFF
--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -100,7 +100,16 @@ def main(input_args=None):
         "--hidden_dim",
         type=int,
         default=64,
-        help="Dimensionality of all hidden representations (default: 64)",
+        help="Dimensionality of hidden representations (default: 64)",
+    )
+    parser.add_argument(
+        "--hidden_dim_grid",
+        type=int,
+        help=(
+            "Dimensionality of hidden representations related to grid nodes "
+            "(grid encodings and in grid-level MLPs)"
+            "(default: None, use same as hidden_dim)"
+        ),
     )
     parser.add_argument(
         "--hidden_layers",


### PR DESCRIPTION
Introduces separate grid hidden dim, --hidden_dim_grid. Also adds a couple linear layers in the model to project from hidden_dim_grid to hidden_dim before applying g2m and m2g. This is neccesary as these GNN-layers can only work with same-dimensional latent vectors.