### PR TITLE
Prototype noise-conditioned ensemble GraphLAM

### DIFF
--- a/neural_lam/metrics.py
+++ b/neural_lam/metrics.py
@@ -227,6 +227,44 @@ def crps_gauss(
     )
 
 
+def crps_ensemble(
+    pred, target, pred_std, mask=None, average_grid=True, sum_vars=True
+):
+    """
+    Empirical CRPS for ensemble forecasts.
+
+    pred: (B, S, T, N, d_state), ensemble prediction
+    target: (B, T, N, d_state), target
+    pred_std: unused, kept for compatibility with the existing metric API
+    """
+    if pred.ndim != 5:
+        raise ValueError(
+            "crps_ensemble expects predictions with shape "
+            "(B, S, T, N, d_state)"
+        )
+    if target.ndim != 4:
+        raise ValueError(
+            "crps_ensemble expects targets with shape (B, T, N, d_state)"
+        )
+
+    # First CRPS term: E |X - y|
+    target_expanded = target.unsqueeze(1)
+    ensemble_target_distance = torch.mean(
+        torch.abs(pred - target_expanded), dim=1
+    )  # (B, T, N, d_state)
+
+    # Second CRPS term: 0.5 E |X - X'|
+    pairwise_distance = torch.abs(pred.unsqueeze(2) - pred.unsqueeze(1))
+    ensemble_spread_penalty = 0.5 * torch.mean(
+        pairwise_distance, dim=(1, 2)
+    )  # (B, T, N, d_state)
+
+    entry_crps = ensemble_target_distance - ensemble_spread_penalty
+    return mask_and_reduce_metric(
+        entry_crps, mask=mask, average_grid=average_grid, sum_vars=sum_vars
+    )
+
+
 DEFINED_METRICS = {
     "mse": mse,
     "mae": mae,
@@ -234,4 +272,5 @@ DEFINED_METRICS = {
     "wmae": wmae,
     "nll": nll,
     "crps_gauss": crps_gauss,
+    "crps_ensemble": crps_ensemble,
 }

--- a/neural_lam/models/__init__.py
+++ b/neural_lam/models/__init__.py
@@ -4,3 +4,4 @@ from .base_hi_graph_model import BaseHiGraphModel
 from .graph_lam import GraphLAM
 from .hi_lam import HiLAM
 from .hi_lam_parallel import HiLAMParallel
+from .noise_ensemble_graph_lam import NoiseEnsembleGraphLAM

--- a/neural_lam/models/noise_ensemble_graph_lam.py
+++ b/neural_lam/models/noise_ensemble_graph_lam.py
@@ -1,0 +1,277 @@
+# Third-party
+import torch
+
+# Local
+from .. import metrics
+from .. import utils
+from .graph_lam import GraphLAM
+
+
+class NoiseEnsembleGraphLAM(GraphLAM):
+    """
+    Prototype ensemble model that wraps the GraphLAM backbone with per-step
+    noise injection and empirical CRPS training.
+
+    This is intentionally simple: it keeps the underlying graph model
+    single-trajectory and creates the ensemble dimension through repeated
+    autoregressive rollouts.
+    """
+
+    def __init__(self, args, config, datastore):
+        super().__init__(args, config=config, datastore=datastore)
+
+        if self.output_std:
+            raise ValueError(
+                "NoiseEnsembleGraphLAM uses sample-based uncertainty and does "
+                "not support --output_std."
+            )
+        if args.loss.lower() != "crps_ensemble":
+            raise ValueError(
+                "NoiseEnsembleGraphLAM is intended to be trained with "
+                "--loss crps_ensemble."
+            )
+        if args.num_pred_samples < 2:
+            raise ValueError(
+                "NoiseEnsembleGraphLAM requires num_pred_samples >= 2."
+            )
+        if args.noise_dim < 1:
+            raise ValueError("NoiseEnsembleGraphLAM requires noise_dim >= 1.")
+        if args.noise_scale <= 0.0:
+            raise ValueError(
+                "NoiseEnsembleGraphLAM requires noise_scale > 0."
+            )
+
+        self.num_pred_samples = args.num_pred_samples
+        self.noise_dim = args.noise_dim
+        self.noise_scale = args.noise_scale
+        self.noise_embedder = utils.make_mlp(
+            [self.noise_dim] + self.mlp_blueprint_end
+        )
+
+        self.val_metrics["crps"] = []
+        self.test_metrics["crps"] = []
+
+    def sample_step_noise(self, batch_size, device):
+        """
+        Draw one latent noise vector per sample in the batch for the current
+        autoregressive step.
+        """
+        return torch.randn(
+            batch_size, self.noise_dim, device=device
+        ) * self.noise_scale
+
+    def predict_step_with_noise(
+        self, prev_state, prev_prev_state, forcing, step_noise
+    ):
+        """
+        Reuse the GraphLAM encode-process-decode path, but perturb the encoded
+        grid representation with a per-sample noise vector before graph
+        message passing.
+        """
+        batch_size = prev_state.shape[0]
+
+        grid_features = torch.cat(
+            (
+                prev_state,
+                prev_prev_state,
+                forcing,
+                self.expand_to_batch(self.grid_static_features, batch_size),
+            ),
+            dim=-1,
+        )
+
+        grid_emb = self.grid_embedder(grid_features)
+        noise_emb = self.noise_embedder(step_noise).unsqueeze(1)
+        grid_emb = grid_emb + noise_emb
+
+        g2m_emb = self.g2m_embedder(self.g2m_features)
+        m2g_emb = self.m2g_embedder(self.m2g_features)
+        mesh_emb = self.embedd_mesh_nodes()
+
+        mesh_emb_expanded = self.expand_to_batch(mesh_emb, batch_size)
+        g2m_emb_expanded = self.expand_to_batch(g2m_emb, batch_size)
+        mesh_rep = self.g2m_gnn(
+            grid_emb, mesh_emb_expanded, g2m_emb_expanded
+        )
+        grid_rep = grid_emb + self.encoding_grid_mlp(grid_emb)
+
+        mesh_rep = self.process_step(mesh_rep)
+
+        m2g_emb_expanded = self.expand_to_batch(m2g_emb, batch_size)
+        grid_rep = self.m2g_gnn(mesh_rep, grid_rep, m2g_emb_expanded)
+
+        pred_delta_mean = self.output_map(grid_rep)
+        rescaled_delta_mean = pred_delta_mean * self.diff_std + self.diff_mean
+        return prev_state + rescaled_delta_mean
+
+    def unroll_prediction(self, init_states, forcing_features, true_states):
+        """
+        Roll out multiple stochastic trajectories and stack them into an
+        ensemble dimension.
+        """
+        batch_size = init_states.shape[0]
+        pred_steps = forcing_features.shape[1]
+        ensemble_predictions = []
+
+        for _ in range(self.num_pred_samples):
+            prev_prev_state = init_states[:, 0]
+            prev_state = init_states[:, 1]
+            prediction_list = []
+
+            for step_i in range(pred_steps):
+                forcing = forcing_features[:, step_i]
+                border_state = true_states[:, step_i]
+                step_noise = self.sample_step_noise(
+                    batch_size=batch_size, device=prev_state.device
+                )
+
+                pred_state = self.predict_step_with_noise(
+                    prev_state, prev_prev_state, forcing, step_noise
+                )
+                new_state = (
+                    self.boundary_mask * border_state
+                    + self.interior_mask * pred_state
+                )
+                prediction_list.append(new_state)
+
+                prev_prev_state = prev_state
+                prev_state = new_state
+
+            ensemble_predictions.append(torch.stack(prediction_list, dim=1))
+
+        prediction = torch.stack(ensemble_predictions, dim=1)
+        return prediction, None
+
+    def common_step(self, batch):
+        init_states, target_states, forcing_features, batch_times = batch
+        prediction, pred_std = self.unroll_prediction(
+            init_states, forcing_features, target_states
+        )
+        return prediction, target_states, pred_std, batch_times
+
+    def training_step(self, batch):
+        prediction, target, _, _ = self.common_step(batch)
+        batch_loss = torch.mean(
+            self.loss(prediction, target, None, mask=self.interior_mask_bool)
+        )
+        self.log_dict(
+            {"train_loss": batch_loss},
+            prog_bar=True,
+            on_step=True,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=batch[0].shape[0],
+        )
+        return batch_loss
+
+    def validation_step(self, batch, batch_idx):
+        prediction, target, _, _ = self.common_step(batch)
+
+        time_step_loss = torch.mean(
+            self.loss(prediction, target, None, mask=self.interior_mask_bool),
+            dim=0,
+        )
+        mean_loss = torch.mean(time_step_loss)
+        val_log_dict = {
+            f"val_loss_unroll{step}": time_step_loss[step - 1]
+            for step in self.args.val_steps_to_log
+            if step <= len(time_step_loss)
+        }
+        val_log_dict["val_mean_loss"] = mean_loss
+        self.log_dict(
+            val_log_dict,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=batch[0].shape[0],
+        )
+
+        ensemble_mean_prediction = torch.mean(prediction, dim=1)
+        self.val_metrics["mse"].append(
+            metrics.mse(
+                ensemble_mean_prediction,
+                target,
+                self.per_var_std,
+                mask=self.interior_mask_bool,
+                sum_vars=False,
+            )
+        )
+        self.val_metrics["crps"].append(
+            self.loss(
+                prediction,
+                target,
+                None,
+                mask=self.interior_mask_bool,
+                sum_vars=False,
+            )
+        )
+
+    def test_step(self, batch, batch_idx):
+        prediction, target, _, _ = self.common_step(batch)
+        time_step_loss = torch.mean(
+            self.loss(prediction, target, None, mask=self.interior_mask_bool),
+            dim=0,
+        )
+        mean_loss = torch.mean(time_step_loss)
+        test_log_dict = {
+            f"test_loss_unroll{step}": time_step_loss[step - 1]
+            for step in self.args.val_steps_to_log
+            if step <= len(time_step_loss)
+        }
+        test_log_dict["test_mean_loss"] = mean_loss
+        self.log_dict(
+            test_log_dict,
+            on_step=False,
+            on_epoch=True,
+            sync_dist=True,
+            batch_size=batch[0].shape[0],
+        )
+
+        ensemble_mean_prediction = torch.mean(prediction, dim=1)
+        for metric_name in ("mse", "mae"):
+            metric_func = metrics.get_metric(metric_name)
+            self.test_metrics[metric_name].append(
+                metric_func(
+                    ensemble_mean_prediction,
+                    target,
+                    self.per_var_std,
+                    mask=self.interior_mask_bool,
+                    sum_vars=False,
+                )
+            )
+
+        self.test_metrics["crps"].append(
+            self.loss(
+                prediction,
+                target,
+                None,
+                mask=self.interior_mask_bool,
+                sum_vars=False,
+            )
+        )
+
+        spatial_loss = self.loss(
+            prediction,
+            target,
+            None,
+            average_grid=False,
+        )
+        log_spatial_losses = spatial_loss[
+            :, [step - 1 for step in self.args.val_steps_to_log]
+        ]
+        self.spatial_loss_maps.append(log_spatial_losses)
+
+        if (
+            self.trainer.is_global_zero
+            and self.plotted_examples < self.n_example_pred
+        ):
+            n_additional_examples = min(
+                ensemble_mean_prediction.shape[0],
+                self.n_example_pred - self.plotted_examples,
+            )
+            self.plot_examples(
+                batch,
+                n_additional_examples,
+                prediction=ensemble_mean_prediction,
+                split="test",
+            )

--- a/neural_lam/train_model.py
+++ b/neural_lam/train_model.py
@@ -13,13 +13,14 @@ from loguru import logger
 # Local
 from . import utils
 from .config import load_config_and_datastore
-from .models import GraphLAM, HiLAM, HiLAMParallel
+from .models import GraphLAM, HiLAM, HiLAMParallel, NoiseEnsembleGraphLAM
 from .weather_dataset import WeatherDataModule
 
 MODELS = {
     "graph_lam": GraphLAM,
     "hi_lam": HiLAM,
     "hi_lam_parallel": HiLAMParallel,
+    "noise_ensemble_graph_lam": NoiseEnsembleGraphLAM,
 }
 
 
@@ -115,6 +116,27 @@ def main(input_args=None):
         help="If models should additionally output std.-dev. per "
         "output dimensions "
         "(default: False (no))",
+    )
+    parser.add_argument(
+        "--num_pred_samples",
+        type=int,
+        default=4,
+        help="Number of ensemble samples to generate for prototype "
+        "ensemble models (default: 4)",
+    )
+    parser.add_argument(
+        "--noise_dim",
+        type=int,
+        default=8,
+        help="Dimensionality of the per-step noise vector used by "
+        "prototype ensemble models (default: 8)",
+    )
+    parser.add_argument(
+        "--noise_scale",
+        type=float,
+        default=1.0,
+        help="Std.-dev. of the Gaussian step noise used by prototype "
+        "ensemble models (default: 1.0)",
     )
 
     # Training options

--- a/tests/test_noise_ensemble_graph_lam.py
+++ b/tests/test_noise_ensemble_graph_lam.py
@@ -1,0 +1,153 @@
+# Standard library
+from pathlib import Path
+from types import SimpleNamespace
+
+# Third-party
+import torch
+
+# First-party
+from neural_lam import config as nlconfig
+from neural_lam import metrics
+from neural_lam.models.noise_ensemble_graph_lam import NoiseEnsembleGraphLAM
+from neural_lam.weather_dataset import WeatherDataset
+from tests.dummy_datastore import DummyDatastore
+
+
+def write_minimal_graph(graph_dir_path: Path, num_grid_nodes: int):
+    graph_dir_path.mkdir(parents=True, exist_ok=True)
+    num_mesh_nodes = 4
+
+    grid_indices = torch.arange(num_grid_nodes, dtype=torch.long)
+    mesh_indices = torch.div(
+        grid_indices,
+        num_grid_nodes // num_mesh_nodes,
+        rounding_mode="floor",
+    )
+    g2m_edge_index = torch.stack((grid_indices, mesh_indices), dim=0)
+    m2g_edge_index = torch.stack((mesh_indices, grid_indices), dim=0)
+    ring_edge_index = torch.tensor(
+        [[0, 1, 2, 3], [1, 2, 3, 0]], dtype=torch.long
+    )
+
+    torch.save([ring_edge_index], graph_dir_path / "m2m_edge_index.pt")
+    torch.save(g2m_edge_index, graph_dir_path / "g2m_edge_index.pt")
+    torch.save(m2g_edge_index, graph_dir_path / "m2g_edge_index.pt")
+    torch.save(
+        [torch.ones(ring_edge_index.shape[1], 1)],
+        graph_dir_path / "m2m_features.pt",
+    )
+    torch.save(
+        torch.ones(g2m_edge_index.shape[1], 1),
+        graph_dir_path / "g2m_features.pt",
+    )
+    torch.save(
+        torch.ones(m2g_edge_index.shape[1], 1),
+        graph_dir_path / "m2g_features.pt",
+    )
+    torch.save(
+        [torch.ones(num_mesh_nodes, 1)],
+        graph_dir_path / "mesh_features.pt",
+    )
+
+
+def build_noise_ensemble_model_and_batch(ar_steps=3, num_pred_samples=4):
+    datastore = DummyDatastore(n_grid_points=16, n_timesteps=12)
+    graph_name = "1level"
+    graph_dir_path = Path(datastore.root_path) / "graph" / graph_name
+
+    if not graph_dir_path.exists():
+        write_minimal_graph(
+            graph_dir_path=graph_dir_path,
+            num_grid_nodes=datastore.boundary_mask.size,
+        )
+
+    dataset = WeatherDataset(
+        datastore=datastore,
+        split="train",
+        ar_steps=ar_steps,
+        standardize=True,
+        num_past_forcing_steps=1,
+        num_future_forcing_steps=1,
+    )
+    samples = [dataset[0], dataset[1]]
+    batch = tuple(torch.stack(parts, dim=0) for parts in zip(*samples))
+
+    class ModelArgs:
+        pass
+
+    model_args = ModelArgs()
+    model_args.output_std = False
+    model_args.loss = "crps_ensemble"
+    model_args.restore_opt = False
+    model_args.n_example_pred = 1
+    model_args.graph = graph_name
+    model_args.hidden_dim = 4
+    model_args.hidden_layers = 1
+    model_args.processor_layers = 2
+    model_args.mesh_aggr = "sum"
+    model_args.lr = 1.0e-3
+    model_args.val_steps_to_log = [1, 2, 3]
+    model_args.metrics_watch = []
+    model_args.var_leads_metrics_watch = {}
+    model_args.num_past_forcing_steps = 1
+    model_args.num_future_forcing_steps = 1
+    model_args.num_pred_samples = num_pred_samples
+    model_args.noise_dim = 3
+    model_args.noise_scale = 0.5
+
+    config = nlconfig.NeuralLAMConfig(
+        datastore=nlconfig.DatastoreSelection(
+            kind=datastore.SHORT_NAME, config_path=datastore.root_path
+        )
+    )
+    model = NoiseEnsembleGraphLAM(
+        args=model_args,
+        datastore=datastore,
+        config=config,
+    )
+    return model, batch, datastore
+
+
+def test_crps_ensemble_is_zero_for_perfect_ensemble():
+    prediction = torch.ones(1, 3, 2, 1, 1)
+    target = torch.ones(1, 2, 1, 1)
+
+    loss = metrics.crps_ensemble(prediction, target, pred_std=None)
+
+    assert torch.allclose(loss, torch.zeros_like(loss))
+
+
+def test_noise_ensemble_graph_lam_common_step_shape():
+    model, batch, datastore = build_noise_ensemble_model_and_batch()
+
+    prediction, target, pred_std, _ = model.common_step(batch)
+
+    assert pred_std is None
+    assert prediction.shape[0] == batch[0].shape[0]
+    assert prediction.shape[1] == model.num_pred_samples
+    assert prediction.shape[2] == target.shape[1]
+    assert prediction.shape[3] == target.shape[2]
+    assert prediction.shape[4] == target.shape[3]
+    assert not torch.allclose(prediction[:, 0], prediction[:, 1])
+
+
+def test_noise_ensemble_graph_lam_training_step_returns_finite_loss():
+    model, batch, _ = build_noise_ensemble_model_and_batch()
+    model.log_dict = lambda *args, **kwargs: None
+
+    loss = model.training_step(batch)
+
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+
+
+def test_noise_ensemble_graph_lam_test_step_keeps_full_grid_spatial_losses():
+    model, batch, datastore = build_noise_ensemble_model_and_batch()
+    model.log_dict = lambda *args, **kwargs: None
+    model.plot_examples = lambda *args, **kwargs: None
+    model._trainer = SimpleNamespace(is_global_zero=False)
+
+    model.test_step(batch, batch_idx=0)
+
+    assert len(model.spatial_loss_maps) == 1
+    assert model.spatial_loss_maps[0].shape[-1] == datastore.boundary_mask.size


### PR DESCRIPTION
## What changed

This PR adds a prototype noise-conditioned ensemble forecasting path on top of the existing GraphLAM backbone.

Changes included here:
- add `crps_ensemble` as an empirical CRPS loss for ensemble forecasts
- add `NoiseEnsembleGraphLAM`, which keeps the inner graph model single-trajectory and creates an ensemble dimension through repeated noisy rollouts
- wire the prototype into the CLI with `noise_ensemble_graph_lam`, `--num_pred_samples`, `--noise_dim`, and `--noise_scale`
- add focused tests for the ensemble loss, forecast contract, finite training loss, and full-grid spatial loss handling at test time

## Why this changed

The goal of this spike is to make the post-#208 ensemble interface discussion more concrete without needing to implement full Graph-EFM first.

This prototype exercises the main orchestration seam that Project 3 depends on:
- deterministic core rollout stays single-trajectory
- ensemble multiplicity is introduced outside that inner path
- forecasts follow an explicit `(B, S, T, N, d_f)` contract
- a sample-based CRPS objective is used to pressure the training/evaluation surface

## Impact

This gives us a simple but non-vacuum test case for the ensemble-model interface:
- we can validate the outer ensemble contract against an actual model path
- we can see where metrics, evaluation, and plotting assumptions start to matter
- we can defer ELBO/predictive-aux-output questions until the first latent-variable model actually needs them

## Non-goals

This PR is intentionally not trying to:
- implement Graph-EFM
- define the final latent-variable / ELBO training output interface
- generalize all plotting/export/evaluation semantics for ensemble models

## Validation

Ran locally:
- `python -m pytest tests/test_noise_ensemble_graph_lam.py -q --noconftest`
- `python -m flake8 neural_lam\metrics.py neural_lam\models\noise_ensemble_graph_lam.py neural_lam\train_model.py tests\test_noise_ensemble_graph_lam.py`
- `python -m py_compile neural_lam\metrics.py neural_lam\models\noise_ensemble_graph_lam.py neural_lam\train_model.py tests\test_noise_ensemble_graph_lam.py`
